### PR TITLE
Add support for self-hosted ClojureScript tests

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -9,15 +9,18 @@
 
   :profiles {:dev {:source-paths ["dev"]
                    :dependencies [[org.clojure/tools.namespace "0.2.11"]
-                                  [org.clojure/test.check "0.9.0"]
+                                  [org.clojure/test.check "0.10.0-alpha2"]
                                   [lein-doo "0.1.7"]
                                   [pjstadig/humane-test-output "0.8.3"]]}}
 
   :plugins [[lein-cljsbuild "1.1.7"]
-            [lein-doo "0.1.10"]]
+            [lein-doo "0.1.10"]
+            [lein-tach "1.0.0"]]
 
   :doo {:build "test"
         :alias {:default [:node]}}
+
+  :tach {:test-runner-ns spec-provider.cljs-self-test-runner}
 
   :cljsbuild {:builds [{:id "test"
                         :source-paths ["src" "test"]

--- a/test/spec_provider/cljs_self_test_runner.cljs
+++ b/test/spec_provider/cljs_self_test_runner.cljs
@@ -1,0 +1,10 @@
+(ns spec-provider.cljs-self-test-runner
+  (:require [clojure.test :refer [run-tests]]
+            [spec-provider.merge-test]
+            [spec-provider.provider-test]
+            [spec-provider.stats-test]))
+
+(run-tests ;;'spec-provider.rewrite-test
+           'spec-provider.merge-test
+           'spec-provider.stats-test
+           'spec-provider.provider-test)


### PR DESCRIPTION
This patch would make it possible to run `spec-provider`'s tests in self-hosted Lumo or Planck:

```
lein tach lumo
```

or

```
lein tach planck
```

If you run the tests, you will see that #22 needs to be fixed before the self-hosted tests will pass.

It bumps the `test.check` dep because `0.9.0` doesn't support self-hosted ClojureScript.

It unfortunately needs to add a duplicate of the existing `spec-provider.cljs-test-runner` namespace, which adds a maintenance burden in needing to be revised as new test namespaces are added. I can't think of a way to combine both into one because once you require `doo.runner` it automatically sets things up for itself, producing a warning like the following:

```
WARNING: doo's exit function was not properly set
#object[TypeError TypeError: null is not an object (evaluating 'doo.runner._STAR_exit_fn_STAR_.call')]
```

(ClojureScript unfortunately doesn't have a way to conditionally do a require.)

The copied test namespace also omits `pjstadig.humane-test-output` because it is evidently not compatible with self-hosted ClojureScript.