### PR TITLE
Support clojure 1.10.1

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -3,7 +3,7 @@
   :url "https://github.com/stathissideris/spec-provider"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.9.0"]
+  :dependencies [[org.clojure/clojure "1.10.1"]
                  [pretty-spec "0.1.3"]
                  [org.clojure/clojurescript "1.10.238"]]
 

--- a/src/spec_provider/stats.cljc
+++ b/src/spec_provider/stats.cljc
@@ -55,7 +55,7 @@
    inst?
    none-of-the-above?])
 
-(s/def ::distinct-values (s/* any?))
+(s/def ::distinct-values (s/coll-of any? :distinct true :kind set? :into #{}))
 (s/def ::sample-count nat-int?)
 (s/def ::min number?)
 (s/def ::max number?)

--- a/test/spec_provider/merge_test.cljc
+++ b/test/spec_provider/merge_test.cljc
@@ -26,11 +26,11 @@
           :distinct-values           #{:c :b :a}
           :keys                      {:a #::st {:name "bar"
                                                 :sample-count 1
-                                                :distinct-values ["bar-val"]
+                                                :distinct-values #{"bar-val"}
                                                 :pred-map {string? #::st {:sample-count 1}}}
                                       :b #::st {:name "baz"
                                                 :sample-count 1
-                                                :distinct-values ["baz-val"]
+                                                :distinct-values #{"baz-val"}
                                                 :pred-map {string? #::st {:sample-count 1}}}}
           :pred-map
           {string? #::st{:sample-count 35
@@ -48,7 +48,7 @@
            :distinct-values           #{:a :b}
            :keys                      {:a #::st {:name "bar"
                                                  :sample-count 1
-                                                 :distinct-values ["bar-val"]
+                                                 :distinct-values #{"bar-val"}
                                                  :pred-map {string? #::st {:sample-count 1}}}}
            :pred-map
            {string? #::st{:sample-count 15
@@ -65,7 +65,7 @@
            :distinct-values           #{:c}
            :keys                      {:b #::st {:name "baz"
                                                  :sample-count 1
-                                                 :distinct-values ["baz-val"]
+                                                 :distinct-values #{"baz-val"}
                                                  :pred-map {string? #::st {:sample-count 1}}}}
            :pred-map
            {string? #::st{:sample-count 20


### PR DESCRIPTION
* Update clojure dependency to latest stable version 1.10.1
* Update :spec-provider.stats/distinct-values spec to conform to most recent
spec function specs

The `distinct-values` spec was using `(s/* any?)` to validate what appears to always be a set. This commit changed the `s/*` function to validate that each spec passed is either `nil?` or `sequential?`:  https://github.com/clojure/spec.alpha/commit/3b34bd32457c42bfea828bdaf4d80a108997247d
 A set is not sequential so this was failing. On the assumption that `distinct-values` is always a set, I've updated the spec to instead check for a set collection containing unique elements that all conform to `any?`.

Let me know if you'd like me to change anything here. If the assumption that `distinct-values` is always supposed to be a set is invalid, happy to update the spec accordingly.